### PR TITLE
DS-3875 - AccessTokenResponse validation checks

### DIFF
--- a/src/Auth/AccessTokenResponse.php
+++ b/src/Auth/AccessTokenResponse.php
@@ -87,7 +87,7 @@ class AccessTokenResponse extends AbstractEntity
     }
 
     /**
-     * @param sting $refresh_token
+     * @param string $refresh_token
      */
     public function setRefreshToken($refresh_token): void
     {

--- a/src/Auth/AccessTokenResponse.php
+++ b/src/Auth/AccessTokenResponse.php
@@ -4,16 +4,27 @@ namespace AllDigitalRewards\Xoxoday\Auth;
 
 use AllDigitalRewards\Xoxoday\AbstractEntity;
 use Psr\Http\Message\ResponseInterface;
+use DateTime;
 
 class AccessTokenResponse extends AbstractEntity
 {
     protected string $access_token = '';
     protected string $token_type = '';
-    protected string $expires_in = '';
+    protected int $expires_in = 0;
     protected string $refresh_token = '';
+
+    /**
+     * Quite unfortunately this does not come from the XOXODay API.
+     * This is generated when the object is instantiated and used when the complete object is stored in a cache.
+     *
+     * @var DateTime $created_on
+     */
+    protected \DateTime $created_on;
 
     public function __construct(ResponseInterface $response)
     {
+        $this->created_on = new \DateTime();
+
         parent::__construct(
             json_decode($response->getBody())
         );
@@ -28,7 +39,7 @@ class AccessTokenResponse extends AbstractEntity
     }
 
     /**
-     * @param mixed $access_token
+     * @param string $access_token
      */
     public function setAccessToken($access_token): void
     {
@@ -36,7 +47,7 @@ class AccessTokenResponse extends AbstractEntity
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getTokenType()
     {
@@ -44,7 +55,7 @@ class AccessTokenResponse extends AbstractEntity
     }
 
     /**
-     * @param mixed $token_type
+     * @param string $token_type
      */
     public function setTokenType($token_type): void
     {
@@ -52,23 +63,23 @@ class AccessTokenResponse extends AbstractEntity
     }
 
     /**
-     * @return mixed
+     * @return int
      */
-    public function getExpiresIn()
+    public function getExpiresIn(): int
     {
         return $this->expires_in;
     }
 
     /**
-     * @param mixed $expires_in
+     * @param int $expires_in
      */
-    public function setExpiresIn($expires_in): void
+    public function setExpiresIn(int $expires_in): void
     {
         $this->expires_in = $expires_in;
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getRefreshToken()
     {
@@ -76,10 +87,53 @@ class AccessTokenResponse extends AbstractEntity
     }
 
     /**
-     * @param mixed $refresh_token
+     * @param sting $refresh_token
      */
     public function setRefreshToken($refresh_token): void
     {
         $this->refresh_token = $refresh_token;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getCreatedOn(): DateTime
+    {
+        return $this->created_on;
+    }
+
+    /**
+     * @param DateTime $created_on
+     */
+    public function setCreatedOn(DateTime $created_on): void
+    {
+        $this->created_on = $created_on;
+    }
+
+    public function isValid(): bool
+    {
+        if (empty($this->refresh_token)) {
+            return false;
+        }
+
+        if (empty($this->access_token)) {
+            return false;
+        }
+
+        if (empty($this->expires_in)) {
+            return false;
+        }
+
+        return !$this->isExpired();
+    }
+
+    public function isExpired(): bool
+    {
+        $expiresOn = $this->created_on->add(new \DateInterval('PT' . $this->expires_in . 'S'));
+        if ($expiresOn <= new DateTime()) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Auth/AccessTokenResponseTest.php
+++ b/tests/Auth/AccessTokenResponseTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AllDigitalRewards\Xoxoday;
+
+use AllDigitalRewards\Xoxoday\Auth\AccessTokenResponse;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class AccessTokenResponseTest extends TestCase
+{
+
+    public function testIsValid()
+    {
+        $response = new Response(
+            200,
+            [],
+            file_get_contents(__DIR__ . '/fixtures/accessTokenResponse.json')
+        );
+        $accessTokenResponse = new AccessTokenResponse($response);
+        self::assertTrue($accessTokenResponse->isValid());
+    }
+
+    public function testIsExpired()
+    {
+        $response = new Response(
+            200,
+            [],
+            file_get_contents(__DIR__ . '/fixtures/accessTokenResponse.json')
+        );
+        $accessTokenResponse = new AccessTokenResponse($response);
+
+        $createdOn = new \DateTime($accessTokenResponse->getExpiresIn() + 60 . ' seconds ago');
+        $accessTokenResponse->setCreatedOn($createdOn);
+
+        self::assertTrue($accessTokenResponse->isExpired());
+    }
+}

--- a/tests/Auth/fixtures/accessTokenResponse.json
+++ b/tests/Auth/fixtures/accessTokenResponse.json
@@ -1,0 +1,6 @@
+{
+  "access_token": "SOME-FAKE-ACCESS-TOKEN=",
+  "token_type": "bearer",
+  "expires_in": "1296000",
+  "refresh_token": "SOME-FAKE-REFRESH-TOKEN"
+}


### PR DESCRIPTION
## Description
DS-3875 - Add validation checks to the access token response to make it easier to deterine if it's still valid when stored in cache.

## Jira Issue Link
https://jira.alldigitalrewards.com/browse/DS-3875

## Has the README / documentation been extended if necessary?
No

## Does this update require changes to public API documentation? 
No

## Tests
### Are there created tests which fail without the change (if possible)?
Yes

### Are all tests passing?
Yes
<img width="687" alt="Screen Shot 2022-03-30 at 2 20 12 PM" src="https://user-images.githubusercontent.com/6137941/160904648-5d628150-dbb8-4678-b9c5-8057e150b2c3.png">

### Have the changes been verified to comply with the security policy requirements?
Yes
